### PR TITLE
feat: 필수 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+src/main/resources/application-dev.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.1'
+    id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+
     // spring data jdbc
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 
@@ -32,10 +33,16 @@ dependencies {
 
     // spring web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // map struct
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     // mysql driver
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/schedule/config/JdbcTemplateConfig.java
+++ b/src/main/java/com/example/schedule/config/JdbcTemplateConfig.java
@@ -1,0 +1,18 @@
+package com.example.schedule.config;
+
+import com.example.schedule.repository.ScheduleRepository;
+import com.example.schedule.repository.ScheduleRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class JdbcTemplateConfig {
+    @Bean
+    public ScheduleRepository scheduleRepository(DataSource dataSource) {
+        return new ScheduleRepositoryImpl(dataSource);
+    }
+}

--- a/src/main/java/com/example/schedule/config/MapperConfig.java
+++ b/src/main/java/com/example/schedule/config/MapperConfig.java
@@ -1,0 +1,14 @@
+package com.example.schedule.config;
+
+import com.example.schedule.mapper.ScheduleMapper;
+import com.example.schedule.mapper.ScheduleMapperImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfig {
+    @Bean
+    public ScheduleMapper scheduleMapper() {
+        return new ScheduleMapperImpl();
+    }
+}

--- a/src/main/java/com/example/schedule/config/SwaggerConfig.java
+++ b/src/main/java/com/example/schedule/config/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.example.schedule.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openApi() {
+        Info info = new Info()
+            .version("v0.0.1")
+            .title("Schedule Management Application")
+            .description("일정 관리 애플리케이션");
+        return new OpenAPI().info(info);
+    }
+}

--- a/src/main/java/com/example/schedule/controller/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/example/schedule/controller/GlobalControllerExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.example.schedule.controller;
+
+import com.example.schedule.exception.ClientException;
+import com.example.schedule.exception.ScheduleNotFoundException;
+import com.example.schedule.controller.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.LocalDateTime;
+
+import static com.example.schedule.exception.ErrorCode.INVALID_ARGUMENT;
+import static com.example.schedule.exception.ErrorCode.INVALID_DATE_FORMAT;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerExceptionHandler {
+
+    @ExceptionHandler(value = ScheduleNotFoundException.class)
+    public ApiResponse<?> scheduleNotFoundExceptionHandler(ScheduleNotFoundException snfe) {
+        return ApiResponse.failure(snfe.getErrorCode().getCode(), snfe.getErrorCode(), snfe.getErrorCode().getMessage());
+    }
+
+    @ExceptionHandler(value = ClientException.class)
+    public ApiResponse<?> clientBadRequestExceptionHandler(ClientException ce) {
+        return ApiResponse.failure(ce.getErrorCode().getCode(), ce.getErrorCode(), ce.getErrorCode().getMessage());
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ApiResponse<?> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException manve) {
+        LocalDateTime now = LocalDateTime.now();
+        log.error("MethodArgumentNotValidException: {}, timestamp: {}", manve.getParameter(), now);
+        return ApiResponse.failure(INVALID_DATE_FORMAT.getCode(), INVALID_DATE_FORMAT, INVALID_DATE_FORMAT.getMessage());
+    }
+
+    @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+    public ApiResponse<?> methodArgumentTypeMismatchExceptionHandler(MethodArgumentTypeMismatchException matme) {
+        LocalDateTime now = LocalDateTime.now();
+        log.error("MethodArgumentTypeMismatchException: {}, timestamp: {}", matme.getParameter(), now);
+        return ApiResponse.failure(INVALID_ARGUMENT.getCode(), INVALID_ARGUMENT, INVALID_ARGUMENT.getMessage());
+    }
+}

--- a/src/main/java/com/example/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedule/controller/ScheduleController.java
@@ -1,0 +1,53 @@
+package com.example.schedule.controller;
+
+import com.example.schedule.controller.request.CreateScheduleRequest;
+import com.example.schedule.controller.request.DeleteScheduleRequest;
+import com.example.schedule.controller.request.UpdateScheduleRequest;
+import com.example.schedule.controller.request.ScheduleSearchCond;
+import com.example.schedule.service.ScheduleDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Schedule", description = "Schedule 관련 API 입니다.")
+public interface ScheduleController {
+
+    @Operation(summary = "일정 생성", description = "새로운 일정을 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "새로운 일정 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청으로 인해 일정 생성 실패(잘못된 데이터 타입)")})
+    com.example.schedule.controller.response.ApiResponse<ScheduleDto> createSchedule(@RequestBody CreateScheduleRequest request);
+
+    @Operation(summary = "일정 목록 조회", description = "작성자명이나 선택한 날짜에 해당하는 일정을 모두 가져옵니다. 조건을 설정하지 않은 경우 모든 결과를 가져옵니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 전체 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "일정 전체 조회 실패(날짜 데이터 포맷 형식)")})
+    com.example.schedule.controller.response.ApiResponse<List<ScheduleDto>> findAllSchedules(@ModelAttribute ScheduleSearchCond cond);
+
+    @Operation(summary = "일정 단건 조회", description = "ID 값에 일치하는 일정을 가져옵니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 단건 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "일정 단건 조회 실패(잘못된 ID 데이터 타입이나 값)"),
+        @ApiResponse(responseCode = "404", description = "일정 조회 실패(ID 값에 해당하는 일정이 없거나 삭제됨)")})
+    com.example.schedule.controller.response.ApiResponse<ScheduleDto> findScheduleById(@PathVariable("scheduleId") Long id);
+
+    @Operation(summary = "일정 수정", description = "ID 값에 일치하는 일정을 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "일정 수정 실패(잘못된 ID 데이터 타입이나 값)"),
+        @ApiResponse(responseCode = "404", description = "일정 수정 실패(ID 값에 해당하는 일정이 없거나 삭제됨)")})
+    com.example.schedule.controller.response.ApiResponse<ScheduleDto> updateSchedule(@PathVariable("scheduleId") Long id, @RequestBody UpdateScheduleRequest request);
+
+    @Operation(summary = "일정 삭제", description = "ID 값에 일치하는 일정을 (소프트)삭제 합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "일정 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "일정 삭제 실패(잘못된 ID 데이터 타입이나 값)"),
+        @ApiResponse(responseCode = "404", description = "일정 삭제 실패(ID 값에 해당하는 일정이 없거나 이미 삭제됨)")})
+    com.example.schedule.controller.response.ApiResponse<Void> deleteSchedule(@PathVariable("scheduleId") Long id, @RequestBody DeleteScheduleRequest request);
+}

--- a/src/main/java/com/example/schedule/controller/ScheduleControllerImpl.java
+++ b/src/main/java/com/example/schedule/controller/ScheduleControllerImpl.java
@@ -1,0 +1,55 @@
+package com.example.schedule.controller;
+
+import com.example.schedule.controller.request.CreateScheduleRequest;
+import com.example.schedule.controller.request.DeleteScheduleRequest;
+import com.example.schedule.controller.request.UpdateScheduleRequest;
+import com.example.schedule.controller.response.ApiResponse;
+import com.example.schedule.controller.request.ScheduleSearchCond;
+import com.example.schedule.service.ScheduleDto;
+import com.example.schedule.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class ScheduleControllerImpl implements ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping
+    public ApiResponse<ScheduleDto> createSchedule(@RequestBody CreateScheduleRequest request) {
+        ScheduleDto createdSchedule = scheduleService.save(request);
+        return ApiResponse.success(200, createdSchedule, "일정 생성 성공");
+    }
+
+    @GetMapping
+    public ApiResponse<List<ScheduleDto>> findAllSchedules(@ModelAttribute ScheduleSearchCond cond) {
+        List<ScheduleDto> schedules = scheduleService.findSchedulesByAuthorOrSelectedDate(cond);
+        return ApiResponse.success(200, schedules, "일정 전체 조회 성공");
+    }
+
+    @GetMapping("/{scheduleId}")
+    public ApiResponse<ScheduleDto> findScheduleById(@PathVariable("scheduleId") Long id) {
+        ScheduleDto findSchedule = scheduleService.findById(id);
+        return ApiResponse.success(200, findSchedule, "일정 단건 조회 성공");
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ApiResponse<ScheduleDto> updateSchedule(@PathVariable("scheduleId") Long id,
+                                                   @RequestBody UpdateScheduleRequest request) {
+        ScheduleDto updatedSchedule = scheduleService.update(id, request);
+        return ApiResponse.success(200, updatedSchedule, "일정 수정 성공");
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ApiResponse<Void> deleteSchedule(@PathVariable("scheduleId") Long id,
+                                            @RequestBody DeleteScheduleRequest request) {
+        scheduleService.delete(id, request);
+        return ApiResponse.success(200, null, "일정 삭제 성공");
+    }
+}

--- a/src/main/java/com/example/schedule/controller/request/CreateScheduleRequest.java
+++ b/src/main/java/com/example/schedule/controller/request/CreateScheduleRequest.java
@@ -1,0 +1,12 @@
+package com.example.schedule.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateScheduleRequest {
+    private final String author;
+    private final String todo;
+    private final String password;
+}

--- a/src/main/java/com/example/schedule/controller/request/DeleteScheduleRequest.java
+++ b/src/main/java/com/example/schedule/controller/request/DeleteScheduleRequest.java
@@ -1,0 +1,14 @@
+package com.example.schedule.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public class DeleteScheduleRequest {
+    private final String password;
+
+    @JsonCreator
+    public DeleteScheduleRequest(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/schedule/controller/request/ScheduleSearchCond.java
+++ b/src/main/java/com/example/schedule/controller/request/ScheduleSearchCond.java
@@ -1,0 +1,16 @@
+package com.example.schedule.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor
+public class ScheduleSearchCond {
+    private final String author;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate selectedDate;
+}

--- a/src/main/java/com/example/schedule/controller/request/UpdateScheduleRequest.java
+++ b/src/main/java/com/example/schedule/controller/request/UpdateScheduleRequest.java
@@ -1,0 +1,13 @@
+package com.example.schedule.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateScheduleRequest {
+
+    private final String todo;
+    private final String author;
+    private final String password;
+}

--- a/src/main/java/com/example/schedule/controller/response/ApiResponse.java
+++ b/src/main/java/com/example/schedule/controller/response/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.example.schedule.controller.response;
+
+import com.example.schedule.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+    private int code;
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private T data;
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private ErrorCode errorCode;
+    private String message;
+    private LocalDateTime timeStamp;
+
+    public static <T> ApiResponse<T> success(int code, T data, String message) {
+        return new ApiResponse<>(true, code, data, null, message, LocalDateTime.now());
+    }
+
+    public static <T> ApiResponse<T> failure(int code, ErrorCode errorCode, String message) {
+        return new ApiResponse<>(false, code, null, errorCode, message, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/example/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/schedule/entity/Schedule.java
@@ -1,0 +1,38 @@
+package com.example.schedule.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Table(name = "schedules")
+@NoArgsConstructor
+public class Schedule {
+
+    @Id
+    @Column(value = "schedule_id")
+    private Long id;
+    private String author;
+    private String todo;
+    private String password;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastUpdated;
+
+    @Column(value = "is_active")
+    private boolean isActive;
+
+    @Builder
+    public Schedule(Long id, String author, String todo, String password, LocalDateTime createdAt, LocalDateTime lastUpdated) {
+        this.id = id;
+        this.author = author;
+        this.todo = todo;
+        this.password = password;
+        this.createdAt = createdAt;
+        this.lastUpdated = lastUpdated;
+    }
+}

--- a/src/main/java/com/example/schedule/exception/ClientException.java
+++ b/src/main/java/com/example/schedule/exception/ClientException.java
@@ -1,0 +1,20 @@
+package com.example.schedule.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ClientException extends RuntimeException {
+
+    private ErrorCode errorCode;
+
+    public ClientException(String message) {
+        super(message);
+    }
+
+    @Builder
+    public ClientException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/example/schedule/exception/ErrorCode.java
+++ b/src/main/java/com/example/schedule/exception/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.example.schedule.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_ARGUMENT(400, "잘못된 인수입니다."),
+    INVALID_DATE_FORMAT(400, "잘못된 날짜 형식입니다."),
+    SCHEDULE_NOT_FOUND(404, "요청에 해당하는 일정을 찾을 수 없습니다."),
+    INVALID_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
+
+    SERVER_ERROR(500, "서버 내부 문제로 인해 요청을 받을 수 없습니다."),
+    ;
+
+
+    private final int code;
+    private final String message;
+
+    ErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+
+}

--- a/src/main/java/com/example/schedule/exception/ScheduleNotFoundException.java
+++ b/src/main/java/com/example/schedule/exception/ScheduleNotFoundException.java
@@ -1,0 +1,20 @@
+package com.example.schedule.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ScheduleNotFoundException extends RuntimeException {
+
+    private ErrorCode errorCode;
+
+    public ScheduleNotFoundException(String message) {
+        super(message);
+    }
+
+    @Builder
+    public ScheduleNotFoundException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/example/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/example/schedule/mapper/ScheduleMapper.java
@@ -1,0 +1,26 @@
+package com.example.schedule.mapper;
+
+import com.example.schedule.entity.Schedule;
+import com.example.schedule.service.ScheduleDto;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(
+    componentModel = "spring",  // spring bean 으로 생성
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,  // 생성자 주입
+    unmappedTargetPolicy = ReportingPolicy.ERROR    // 매핑 실패 시 컴파일 에러
+)
+public interface ScheduleMapper {
+
+    @Mapping(target = "scheduleId", source = "id")
+    ScheduleDto scheduleToScheduleDto(Schedule schedule);
+
+    List<ScheduleDto> schedulesToScheduleDtos(List<Schedule> schedules);
+
+//    @Mapping(target = "id", source = "scheduleId")
+//    Schedule scheduleDtoToSchedule(ScheduleDto scheduleDto);
+}

--- a/src/main/java/com/example/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,20 @@
+package com.example.schedule.repository;
+
+import com.example.schedule.entity.Schedule;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface ScheduleRepository {
+
+    Schedule save(String author, String todo, String password);
+
+    List<Schedule> findAll(String author, LocalDate selectedDate);
+
+    Optional<Schedule> findById(Long scheduleId);
+
+    Schedule update(Long scheduleId, String author, String todo);
+
+    void delete(Long scheduleId);
+}

--- a/src/main/java/com/example/schedule/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/schedule/repository/ScheduleRepositoryImpl.java
@@ -1,0 +1,136 @@
+package com.example.schedule.repository;
+
+import com.example.schedule.entity.Schedule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+public class ScheduleRepositoryImpl implements ScheduleRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert jdbcInsert;
+
+    public ScheduleRepositoryImpl(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        this.jdbcInsert = new SimpleJdbcInsert(dataSource)
+            .withTableName("schedules")
+            .usingGeneratedKeyColumns("schedule_id");
+    }
+
+
+    @Override
+    public Schedule save(String author, String todo, String password) {
+        final LocalDateTime now = LocalDateTime.now();
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("author", author)
+            .addValue("todo", todo)
+            .addValue("password", password)
+            .addValue("created_at", now)
+            .addValue("last_updated", now)
+            .addValue("is_active", true);
+
+        Number key = jdbcInsert.executeAndReturnKey(params);
+
+        return Schedule.builder()
+            .id(key.longValue())
+            .author(author)
+            .todo(todo)
+            .password(password)
+            .createdAt(now)
+            .lastUpdated(now)
+            .build();
+    }
+
+    @Override
+    public List<Schedule> findAll(String author, LocalDate selectedDate) {
+        String sql = "select * from schedules where is_active = true";
+
+        if (StringUtils.hasText(author)) {
+            sql += " and author like concat('%', '" + author + "', '%')";
+
+        }
+
+        if (selectedDate != null) {
+            sql += " and last_updated between '" + selectedDate + "' and date_add('" + selectedDate + "', interval '23:59:59' hour_second)";
+        }
+
+        sql += " order by last_updated desc";
+
+        return jdbcTemplate.query(sql, scheduleRowMapper());
+    }
+
+    @Override
+    public Optional<Schedule> findById(Long scheduleId) {
+        String sql = "select * from schedules where schedule_id = :scheduleId and is_active = true";
+        SqlParameterSource param = new MapSqlParameterSource("scheduleId", scheduleId);
+
+        List<Schedule> schedules = jdbcTemplate.query(sql, param, scheduleRowMapper());
+        return schedules.stream().findFirst();
+    }
+
+    @Override
+    public Schedule update(Long scheduleId, String author, String todo) {
+        String sql = "update schedules set";
+
+        if (!StringUtils.hasText(author) && StringUtils.hasText(todo)) {
+            throw new RuntimeException("변경할 값을 입력해주세요");
+        }
+
+        boolean commaFlag = false;
+        if (StringUtils.hasText(author)) {
+            sql += " author = '" + author + "'";
+            commaFlag = true;
+        }
+
+        if (StringUtils.hasText(todo)) {
+            if (commaFlag) {
+                sql += ",";
+            }
+            sql += " todo = '" + todo + "'";
+        }
+        sql += ", last_updated = '" + LocalDateTime.now() + "' where schedule_id = :scheduleId and is_active = true";
+
+        SqlParameterSource params = new MapSqlParameterSource("scheduleId", scheduleId);
+        jdbcTemplate.update(sql, params);
+
+        sql = "select * from schedules where schedule_id = :scheduleId and is_active = true";
+        SqlParameterSource param = new MapSqlParameterSource("scheduleId", scheduleId);
+
+        return jdbcTemplate.queryForObject(sql, param, scheduleRowMapper());
+    }
+
+    @Override
+    public void delete(Long scheduleId) {
+        String sql = "update schedules set is_active = false where schedule_id = :scheduleId";
+
+        SqlParameterSource param = new MapSqlParameterSource("scheduleId", scheduleId);
+        jdbcTemplate.update(sql, param);
+    }
+
+    private RowMapper<Schedule> scheduleRowMapper() {
+        return (rs, rowNum) ->
+            Schedule.builder()
+                .id(rs.getLong("schedule_id"))
+                .author(rs.getString("author"))
+                .todo(rs.getString("todo"))
+                .password(rs.getString("password"))
+                .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+                .lastUpdated(rs.getTimestamp("last_updated").toLocalDateTime())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/schedule/service/ScheduleDto.java
+++ b/src/main/java/com/example/schedule/service/ScheduleDto.java
@@ -1,0 +1,16 @@
+package com.example.schedule.service;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@RequiredArgsConstructor
+public class ScheduleDto {
+    private final Long scheduleId;
+    private final String author;
+    private final String todo;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime lastUpdated;
+}

--- a/src/main/java/com/example/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/schedule/service/ScheduleService.java
@@ -1,0 +1,21 @@
+package com.example.schedule.service;
+
+import com.example.schedule.controller.request.CreateScheduleRequest;
+import com.example.schedule.controller.request.DeleteScheduleRequest;
+import com.example.schedule.controller.request.UpdateScheduleRequest;
+import com.example.schedule.controller.request.ScheduleSearchCond;
+
+import java.util.List;
+
+public interface ScheduleService {
+
+    ScheduleDto save(CreateScheduleRequest request);
+
+    List<ScheduleDto> findSchedulesByAuthorOrSelectedDate(ScheduleSearchCond cond);
+
+    ScheduleDto findById(Long scheduleId);
+
+    ScheduleDto update(Long scheduleId, UpdateScheduleRequest dto);
+
+    void delete(Long scheduleId, DeleteScheduleRequest request);
+}

--- a/src/main/java/com/example/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedule/service/ScheduleServiceImpl.java
@@ -1,0 +1,79 @@
+package com.example.schedule.service;
+
+import com.example.schedule.exception.ClientException;
+import com.example.schedule.exception.ScheduleNotFoundException;
+import com.example.schedule.controller.request.CreateScheduleRequest;
+import com.example.schedule.controller.request.DeleteScheduleRequest;
+import com.example.schedule.entity.Schedule;
+import com.example.schedule.mapper.ScheduleMapper;
+import com.example.schedule.repository.ScheduleRepository;
+import com.example.schedule.controller.request.UpdateScheduleRequest;
+import com.example.schedule.controller.request.ScheduleSearchCond;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.example.schedule.exception.ErrorCode.INVALID_PASSWORD;
+import static com.example.schedule.exception.ErrorCode.SCHEDULE_NOT_FOUND;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ScheduleServiceImpl implements ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleMapper scheduleMapper;
+
+    @Override
+    @Transactional
+    public ScheduleDto save(CreateScheduleRequest request) {
+        Schedule createdSchedule = scheduleRepository.save(request.getAuthor(), request.getTodo(), request.getPassword());
+        return scheduleMapper.scheduleToScheduleDto(createdSchedule);
+    }
+
+    @Override
+    public List<ScheduleDto> findSchedulesByAuthorOrSelectedDate(ScheduleSearchCond cond) {
+        return scheduleRepository.findAll(cond.getAuthor(), cond.getSelectedDate())
+            .stream()
+            .map(scheduleMapper::scheduleToScheduleDto)
+            .toList();
+    }
+
+    @Override
+    public ScheduleDto findById(Long scheduleId) {
+        Schedule findSchedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow(() -> new ScheduleNotFoundException(SCHEDULE_NOT_FOUND));
+        return scheduleMapper.scheduleToScheduleDto(findSchedule);
+    }
+
+    @Override
+    @Transactional
+    public ScheduleDto update(Long scheduleId, UpdateScheduleRequest dto) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow(() -> new ScheduleNotFoundException(SCHEDULE_NOT_FOUND));
+
+        if (!schedule.getPassword().equals(dto.getPassword())) {
+            throw new ClientException(INVALID_PASSWORD);
+        }
+
+        Schedule updatedSchedule = scheduleRepository.update(scheduleId, dto.getAuthor(), dto.getTodo());
+        return scheduleMapper.scheduleToScheduleDto(updatedSchedule);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long scheduleId, DeleteScheduleRequest request) {
+        Schedule findSchedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow(() -> new ScheduleNotFoundException(SCHEDULE_NOT_FOUND));
+
+        if (!findSchedule.getPassword().equals(request.getPassword())) {
+            throw new ClientException(INVALID_PASSWORD);
+        }
+
+        scheduleRepository.delete(scheduleId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  config:
+    import:
+      - classpath:application-dev.yml
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: alpha
+    tags-sorter: alpha
+    disable-swagger-default-url: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  api-docs:
+    path: /api-docs


### PR DESCRIPTION
### 일정 생성 및 조회

일정 생성 시, 포함되어야 할 데이터

- `할 일`, `작성자명`, `비밀번호`, `작성/수정일` 저장
- `작성/수정일`은 날짜와 시간 모두 포함
- 각 일정의 고유 식별자 자동 생성 및 관리
- 최초 입력 시, 수정일은 작성일과 동일

### 전체 일정 조회

다음 조건을 바탕으로 등록된 일정 목록을 전체 조회를 수행.
조건 중 한 가지만을 충족하거나, 둘 다 충족을 하지 않을 수도, 두 가지를 모두 충족할 수도 있음.
결과를 `수정일` 기준 내림차순으로 정렬하여 조회

- 수정일 (형식: `yyyy-MM-dd`)
- 작성자명

### 선택 일정 조회

일정의 고유 식별자를 사용하여 일정 단건 조회
